### PR TITLE
楽天銀行の新支店追加と八十二長野銀行の合併対応

### DIFF
--- a/data/banks.json
+++ b/data/banks.json
@@ -260,10 +260,10 @@
   },
   "0143":{
     "code":"0143",
-    "name":"八十二",
-    "kana":"ハチジユウニ",
-    "hira":"はちじゆうに",
-    "roma":"hachijiyuuni"
+    "name":"八十二長野",
+    "kana":"ハチジユウニナガノ",
+    "hira":"はちじゆうにながの",
+    "roma":"hachijiyuuninagano"
   },
   "0144":{
     "code":"0144",

--- a/data/branches/0036.json
+++ b/data/branches/0036.json
@@ -342,6 +342,20 @@
     "hira":"こ－ど",
     "roma":"ko-do"
   },
+  "249":{
+    "code":"249",
+    "name":"マイク",
+    "kana":"マイク",
+    "hira":"まいく",
+    "roma":"maiku"
+  },
+  "250":{
+    "code":"250",
+    "name":"リード",
+    "kana":"リ－ド",
+    "hira":"り－ど",
+    "roma":"ri-do"
+  },
   "251":{
     "code":"251",
     "name":"第一営業",
@@ -383,6 +397,34 @@
     "kana":"ウリアゲニユウキンダイニ",
     "hira":"うりあげにゆうきんだいに",
     "roma":"uriageniyuukindaini"
+  },
+  "271":{
+    "code":"271",
+    "name":"デュオ",
+    "kana":"デユオ",
+    "hira":"でゆお",
+    "roma":"deyuo"
+  },
+  "272":{
+    "code":"272",
+    "name":"ラップ",
+    "kana":"ラツプ",
+    "hira":"らつぷ",
+    "roma":"ratsupu"
+  },
+  "273":{
+    "code":"273",
+    "name":"プリモ",
+    "kana":"プリモ",
+    "hira":"ぷりも",
+    "roma":"purimo"
+  },
+  "274":{
+    "code":"274",
+    "name":"ジャム",
+    "kana":"ジヤム",
+    "hira":"じやむ",
+    "roma":"jiyamu"
   },
   "301":{
     "code":"301",


### PR DESCRIPTION
## 概要

このPRは、楽天銀行の新支店追加と八十二長野銀行の合併に対応するデータ更新を行います。

Fixes #31

### 1. 楽天銀行の新支店追加

2025年12月15日に発表され、2025年12月22日より運用開始された6つの新支店を追加しました。

**追加した支店:**
- **支店コード 249**: マイク (Maiku)
- **支店コード 250**: リード (Rīdo)
- **支店コード 271**: デュオ (Duo)
- **支店コード 272**: ラップ (Rappu)
- **支店コード 273**: プリモ (Purimo)
- **支店コード 274**: ジャム (Jamu)

### 2. 八十二長野銀行の合併対応

2026年1月1日付の八十二銀行と長野銀行の合併を反映しました。

**更新内容:**
- **銀行コード 0143**: 八十二 → 八十二長野 (Hachijuni-Nagano Bank)

金融庁による合併認可: 2025年12月25日  
合併発効日: 2026年1月1日

## 検証

両方の変更は公式情報源で検証済みです：
- 楽天銀行公式発表: https://www.rakuten-bank.co.jp/info/2025/251215.html
- 八十二長野銀行合併認可: https://www.fsa.go.jp/news/r7/ginkou/20251225/20251225.html

## 変更ファイル

- `data/branches/0036.json`: 楽天銀行の6つの新支店を追加
- `data/banks.json`: 銀行コード0143の名称を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)